### PR TITLE
Added Channel switching + bug fixes

### DIFF
--- a/src/views/chatroom.html
+++ b/src/views/chatroom.html
@@ -74,7 +74,7 @@
             <div class="col-sm-2">
                <div class="chaddon_headings">Channels</div>
                <div class="users_online">
-                  <ul class="list-group list-unstyled">
+                  <ul id="userOpenChats" class="list-group list-unstyled">
                      <li class="list-group-item-action">
                         <a href="/">Home</a>
                      </li>


### PR DESCRIPTION
Switching between channels your currently on can be done by clicking the channels in the chat room's channel box.
Chat is cleared and updated with chat history when switching channels.
User won't receive messages from channels other then the one currently focused on. They are still considered to be on the original channel for that window even if on a different channel.

Bug where usernames not disappearing on return is fixed.

Potential negative side effects:
If a channel is identical to a username, you can send messages to that username. I suggest adding username restrictions to avoid them looking like URLs.
You can close one tab and still use the chat while not being on it if you channel swapped into that channel before closing its original tab.