### PR TITLE
channels, user list, channel list, channel switching

### DIFF
--- a/browser_extension/css/style.css
+++ b/browser_extension/css/style.css
@@ -135,6 +135,13 @@ ul {
   text-align: right;
 }
 
+.chaddon_headings {
+    font-family: "Bookman Old Style","Times New Roman";
+    font-weight: bold;
+    font-size: 18px;
+    padding: 10px 0px 0px 48px ;
+}
+
 /* Input */
 
 .inputMessage {
@@ -148,3 +155,4 @@ ul {
   right: 0;
   width: 100%;
 }
+

--- a/browser_extension/js/main.js
+++ b/browser_extension/js/main.js
@@ -25,7 +25,7 @@ $(function () {
 
   var socket = io.connect('http://localhost:3000');
   
-  var currentchannel;
+  var currentChannel;
 
   // Payload stores the username and channel
   var payload = {
@@ -36,7 +36,7 @@ $(function () {
   chrome.tabs.query({'active': true, 'lastFocusedWindow': true}, function (tabs) {
     var url = new URL(tabs[0].url);
     payload.domain = url.hostname;
-	currentchannel = payload.domain;
+    currentChannel = payload.domain;
   });
 
   function loginGoogleUser() {
@@ -56,10 +56,8 @@ $(function () {
 
       if (response.emails.length > 0) {
         console.log("response.emails is", response.emails);
-        console.log("response.domainis", response.domain);
 
         payload.username = response.emails[0].split('@')[0]; // A Google users "username" is their email
-        //payload.domain = response.domain; // Stores the domain of the current active tab
         console.log("Payload", payload);
 
         if (payload.username) {
@@ -100,7 +98,7 @@ $(function () {
         $chatPage.show();
         $loginPage.off('click');
         $currentInput = $inputMessage.focus();
-		$("#chat_name").text(currentchannel);
+		$("#chat_name").text(currentChannel);
         // Tell the server your username
         socket.emit('add user', payload);
       }
@@ -128,7 +126,7 @@ $(function () {
       // tell server to execute 'new message' and send along one parameter
       socket.emit('new message', { 
 	    message: message,
-		room: currentchannel
+		room: currentChannel
 	  });
     }
   }
@@ -319,16 +317,16 @@ $(function () {
   //handle clicking channels in the channel box
   $("div").on("click", ".changechannel", function(e){
 	e.preventDefault();
-	if (currentchannel != e.currentTarget.innerHTML){
-		var oldchannel;
-		if (currentchannel != payload.domain){ //you will leave old channel unless old channel is your current room since that affects other tabs
-			oldchannel = currentchannel;
+	if (currentChannel != e.currentTarget.innerHTML){
+		var oldChannel;
+		if (currentChannel != payload.domain){ //you will leave old channel unless old channel is your current room since that affects other tabs
+			oldChannel = currentChannel;
 		}
-		currentchannel = e.currentTarget.innerHTML;
-		$("#chat_name").text(currentchannel);
-		socket.emit("viewchannel", {
-			old: oldchannel,
-			room: currentchannel
+		currentChannel = e.currentTarget.innerHTML;
+		$("#chat_name").text(currentChannel);
+		socket.emit("viewChannel", {
+			oldChannel: oldChannel,
+			room: currentChannel
 		});
     }
   });
@@ -348,13 +346,13 @@ $(function () {
 
   // Whenever the server emits 'new message', update the chat body
   socket.on('new message', function (data) {
-	if (data.room == currentchannel){
+	if (data.room == currentChannel){
       addChatMessage(data);
 	}
   });
 
   socket.on("updateUsers", function(data) {
-	if (data.room == currentchannel) {
+	if (data.room == currentChannel) {
 		$("#onlineUserList").html(""); //This is being called and clearing the list because data is not null
 		for (var key in data.usernames) {
 	      //add the user to the list of online users

--- a/browser_extension/js/main.js
+++ b/browser_extension/js/main.js
@@ -24,12 +24,20 @@ $(function () {
   var $currentInput = $usernameInput.focus();
 
   var socket = io.connect('http://localhost:3000');
+  
+  var currentchannel;
 
   // Payload stores the username and channel
   var payload = {
     username: "",
     domain: ""
   }
+  
+  chrome.tabs.query({'active': true, 'lastFocusedWindow': true}, function (tabs) {
+    var url = new URL(tabs[0].url);
+    payload.domain = url.hostname;
+	currentchannel = payload.domain;
+  });
 
   function loginGoogleUser() {
     // Use identity API to get the logged in user.
@@ -51,7 +59,7 @@ $(function () {
         console.log("response.domainis", response.domain);
 
         payload.username = response.emails[0].split('@')[0]; // A Google users "username" is their email
-        payload.domain = response.domain; // Stores the domain of the current active tab
+        //payload.domain = response.domain; // Stores the domain of the current active tab
         console.log("Payload", payload);
 
         if (payload.username) {
@@ -92,7 +100,7 @@ $(function () {
         $chatPage.show();
         $loginPage.off('click');
         $currentInput = $inputMessage.focus();
-
+		$("#chat_name").text(currentchannel);
         // Tell the server your username
         socket.emit('add user', payload);
       }
@@ -118,7 +126,10 @@ $(function () {
         show(payload.username, message);
       }
       // tell server to execute 'new message' and send along one parameter
-      socket.emit('new message', message);
+      socket.emit('new message', { 
+	    message: message,
+		room: currentchannel
+	  });
     }
   }
 
@@ -304,6 +315,23 @@ $(function () {
   $inputMessage.click(function () {
     $inputMessage.focus();
   });
+  
+  //handle clicking channels in the channel box
+  $("div").on("click", ".changechannel", function(e){
+	e.preventDefault();
+	if (currentchannel != e.currentTarget.innerHTML){
+		var oldchannel;
+		if (currentchannel != payload.domain){ //you will leave old channel unless old channel is your current room since that affects other tabs
+			oldchannel = currentchannel;
+		}
+		currentchannel = e.currentTarget.innerHTML;
+		$("#chat_name").text(currentchannel);
+		socket.emit("viewchannel", {
+			old: oldchannel,
+			room: currentchannel
+		});
+    }
+  });
 
   // Socket events
 
@@ -320,9 +348,45 @@ $(function () {
 
   // Whenever the server emits 'new message', update the chat body
   socket.on('new message', function (data) {
-    addChatMessage(data);
+	if (data.room == currentchannel){
+      addChatMessage(data);
+	}
   });
 
+  socket.on("updateUsers", function(data) {
+	if (data.room == currentchannel) {
+		$("#onlineUserList").html(""); //This is being called and clearing the list because data is not null
+		for (var key in data.usernames) {
+	      //add the user to the list of online users
+		  $("#onlineUserList").append("<li class='userOnline'>" + key + "</li>");
+		}
+	}
+  });
+  
+  socket.on("updateRooms",function(data){
+	  if (data != null && data.disconnectFlag == undefined){
+		$("#userOpenChats").append("<li class='userOnline'><a href='' class='changechannel' value='"+data.room+"'>"+data.room+"</div></li>");
+	  }
+	  else if (data.disconnectFlag == true){
+		var liRooms = document.getElementsByClassName("userOnline");
+		for (var i = 0; i < liRooms.length; i++) {
+			var liRoom = liRooms[i].textContent;
+			if (liRoom == data.room) {
+			  document.getElementsByClassName("userOnline")[i].remove();
+			}
+		}
+	  }
+  });
+  
+  //load history
+  socket.on("loadHistory", function(data) {
+	$(".messages").empty();
+    for (var i = 0; i < data.length; i++) {
+		console.log(data[i]);
+      addChatMessage(data[i]);
+    }
+  });
+  
   // Whenever the server emits 'user joined', log it in the chat body
   socket.on('user joined', function (data) {
     log(data.username + ' joined');
@@ -353,6 +417,7 @@ $(function () {
   socket.on('reconnect', function () {
     log('you have been reconnected');
     if (payload.username) {
+	  $("#chat_name").text(payload.domain);
       socket.emit('add user', payload);
     }
   });

--- a/browser_extension/src/bg/authentication.js
+++ b/browser_extension/src/bg/authentication.js
@@ -54,13 +54,6 @@ function xhrWithAuth(callback) {
     }
   }
 
-  /*** Get domain of the users current active tab ***/
-  chrome.tabs.getSelected(null, function (tab, response) {
-    var url = new URL(tab.url);
-    domain = url.hostname;
-    console.log("URL", domain);
-  });
-
   /*** Return the email addresses when main.js asks for it ***/
   chrome.extension.onMessage.addListener(function (request, sender, sendResponse) {
     console.log("Sending emails:", emails);

--- a/browser_extension/src/browser_action/browser_action.html
+++ b/browser_extension/src/browser_action/browser_action.html
@@ -13,7 +13,24 @@
 <body>
   <ul class="pages">
     <li class="chat page">
+	  <div id="channels_users">
+	    <div class="chaddon_headings">Channels</div>
+	    <div class="users_online">
+		  <ul id="userOpenChats" class="list-group list-unstyled">
+			 <li class="list-group-item-action">
+			 </li>
+			 <li class="list-group-item-action active">
+			 </li>
+		  </ul>
+	    </div>
+	    <div class="container"></div>
+	    <div class="chaddon_headings">Online</div>
+	    <div class="users_online">
+		  <ul id="onlineUserList" class="list-unstyled"></ul>
+	    </div>
+	  </div>
       <div class="chatArea">
+		<div id="chat_name" class="chaddon_headings"></div>
         <ul class="messages"></ul>
       </div>
       <input class="inputMessage" placeholder="Type here..." />

--- a/src/chaddon.js
+++ b/src/chaddon.js
@@ -59,7 +59,7 @@ io.on('connection', function (socket) {
     } else { //user is already in this chat
       localUser["" + socket.channel][socket.username] = localUser["" + socket.channel][socket.username]+1;
     }
-	
+
     numUsers += 1;
     addedUser = true;
     io.to(socket.channel).emit('login', {

--- a/src/chaddon.js
+++ b/src/chaddon.js
@@ -59,7 +59,7 @@ io.on('connection', function (socket) {
     } else { //user is already in this chat
       localUser["" + socket.channel][socket.username] = localUser["" + socket.channel][socket.username]+1;
     }
-
+	
     numUsers += 1;
     addedUser = true;
     io.to(socket.channel).emit('login', {
@@ -81,7 +81,6 @@ io.on('connection', function (socket) {
         });
       }
     }
-
 
     if (history[socket.channel] !== undefined) {
       socket.emit("loadHistory", history[socket.channel]);
@@ -121,9 +120,9 @@ io.on('connection', function (socket) {
     });
   });
 
-  socket.on("viewchannel", function (data) {
-    if (data.oldchannel != undefined) {
-      socket.leave(data.oldchannel);
+  socket.on("viewChannel", function (data) {
+    if (data.oldChannel != undefined) {
+      socket.leave(data.oldChannel);
     }
     socket.join(data.room);
     socket.emit("updateUsers", {

--- a/src/chaddon.js
+++ b/src/chaddon.js
@@ -16,6 +16,12 @@ app.use(express.static(path.join(__dirname, '../browser_extension')));
 
 var numUsers = 0;
 
+//usernames in room
+var localUser = {};
+
+//storing room specific history
+var history = {};
+
 io.on('connection', function (socket) {
   var addedUser = false;
 
@@ -24,6 +30,7 @@ io.on('connection', function (socket) {
     if (addedUser) {
       return;
     };
+	
     console.log("Adding: ", payload.username);
     console.log("Domain: ", payload.domain);
     // we store the username in the socket session for this client
@@ -31,27 +38,74 @@ io.on('connection', function (socket) {
     socket.channel = payload.domain;
     console.log("socket.channel : ", socket.channel);
 
+	//add user to channel
     socket.join(socket.channel);
+	
+	if (localUser["" + socket.channel] === undefined) {
+	  localUser["" + socket.channel] = {};
+	}
+	//if user isn't already in this chat somewhere else
+	if (localUser["" + socket.channel][socket.username] === undefined){
+	  localUser["" + socket.channel][socket.username] = 1;
+	  //add channel to user's other tabs
+	  io.in(socket.username).emit("updateRooms", {
+        room: socket.channel
+      });
+		
+      socket.broadcast.to(socket.channel).emit('user joined', {
+        username: socket.username,
+        numUsers: numUsers
+      });
+	} 
+	else { //user is already in this chat
+      localUser["" + socket.channel][socket.username]++;
+	}
 
     numUsers += 1;
     addedUser = true;
     io.to(socket.channel).emit('login', {
       numUsers: numUsers
     });
-
-    socket.broadcast.to(socket.channel).emit('user joined', {
-      username: socket.username,
-      numUsers: numUsers
-    });
+	
+	//add user to list of users on the channel
+    io.in(socket.channel).emit("updateUsers", {
+	  usernames: localUser[socket.channel],
+	  room: socket.channel
+	});
+	
+    socket.join(socket.username);
+	//add user's current channels
+	for (var i in localUser) {
+	  if (localUser[i][socket.username] != undefined) {
+	    socket.emit("updateRooms", {
+		  room: i
+	    });
+	  }
+    }
+	
+	
+    if (history[socket.channel] !== undefined) {
+	  socket.emit("loadHistory", history[socket.channel]);
+    } else {
+	  history[socket.channel] = [];
+    }
   });
 
   // when the client emits 'new message', this listens and executes
   socket.on('new message', function (data) {
     // we tell the client to execute 'new message'
-    socket.to(socket.channel).emit('new message', {
+	var message = {
       username: socket.username,
-      message: data
-    });
+      message: data.message,
+	  room: data.room
+	};
+	
+	if (history[data.room] === undefined) {
+	  history[data.room] = [];
+	}
+	history[data.room].push(message);
+		  
+    socket.to(data.room).emit('new message', message);
   });
 
   // when the client emits 'typing', we broadcast it to others
@@ -68,16 +122,55 @@ io.on('connection', function (socket) {
     });
   });
 
+  socket.on("viewchannel", function (data) {
+    if (data.oldchannel != undefined) {
+      socket.leave(data.oldchannel);
+    }
+    socket.join(data.room);
+    socket.emit("updateUsers", {
+        usernames: localUser[data.room],
+        room: data.room
+    });
+    if (history[data.room] !== undefined) {
+      socket.emit("loadHistory", history[data.room]);
+    }
+  });
+  
   // when the user disconnects.. perform this
   socket.on('disconnect', function () {
     if (addedUser) {
       numUsers -= 1;
-
-      // echo globally that this client has left
-      socket.broadcast.to(socket.channel).emit('user left', {
-        username: socket.username,
-        numUsers: numUsers
-      });
+	  if (localUser[socket.channel] != undefined){
+		//user is in this chat in multiple instances
+		if (localUser[socket.channel][socket.username] > 1){
+			localUser[socket.channel][socket.username]--;
+		} 
+		else if (delete localUser[socket.channel][socket.username]) {
+          if (!Object.keys(localUser[socket.channel]).length) { //last user left; room now empty
+            delete localUser[socket.channel];
+            delete history[socket.channel];
+          }
+		  
+		  io.sockets.in(socket.username).emit("updateRooms", {
+			disconnectFlag: true,
+			room: socket.channel
+		  });
+		  
+          // echo globally that this client has left
+          socket.broadcast.to(socket.channel).emit('user left', {
+            username: socket.username,
+            numUsers: numUsers
+          });
+        }
+	  }
+	  
+      io.in(socket.channel).emit("updateUsers", {
+	    usernames: localUser[socket.channel],
+	    room: socket.channel
+	  });
+	  
+      socket.leave(socket.username);
+      socket.leave(socket.channel);
     }
   });
 });

--- a/src/chaddon.js
+++ b/src/chaddon.js
@@ -30,7 +30,7 @@ io.on('connection', function (socket) {
     if (addedUser) {
       return;
     };
-	
+
     console.log("Adding: ", payload.username);
     console.log("Domain: ", payload.domain);
     // we store the username in the socket session for this client
@@ -38,73 +38,72 @@ io.on('connection', function (socket) {
     socket.channel = payload.domain;
     console.log("socket.channel : ", socket.channel);
 
-	//add user to channel
+    //add user to channel
     socket.join(socket.channel);
-	
-	if (localUser["" + socket.channel] === undefined) {
-	  localUser["" + socket.channel] = {};
-	}
-	//if user isn't already in this chat somewhere else
-	if (localUser["" + socket.channel][socket.username] === undefined){
-	  localUser["" + socket.channel][socket.username] = 1;
-	  //add channel to user's other tabs
-	  io.in(socket.username).emit("updateRooms", {
+
+    if (localUser["" + socket.channel] === undefined) {
+      localUser["" + socket.channel] = {};
+    }
+    //if user isn't already in this chat somewhere else
+    if (localUser["" + socket.channel][socket.username] === undefined) {
+      localUser["" + socket.channel][socket.username] = 1;
+      //add channel to user's other tabs
+      io.in(socket.username).emit("updateRooms", {
         room: socket.channel
       });
-		
+
       socket.broadcast.to(socket.channel).emit('user joined', {
         username: socket.username,
         numUsers: numUsers
       });
-	} 
-	else { //user is already in this chat
-      localUser["" + socket.channel][socket.username]++;
-	}
+    } else { //user is already in this chat
+      localUser["" + socket.channel][socket.username] = localUser["" + socket.channel][socket.username]+1;
+    }
 
     numUsers += 1;
     addedUser = true;
     io.to(socket.channel).emit('login', {
       numUsers: numUsers
     });
-	
-	//add user to list of users on the channel
+
+    //add user to list of users on the channel
     io.in(socket.channel).emit("updateUsers", {
-	  usernames: localUser[socket.channel],
-	  room: socket.channel
-	});
-	
+      usernames: localUser[socket.channel],
+      room: socket.channel
+    });
+
     socket.join(socket.username);
-	//add user's current channels
-	for (var i in localUser) {
-	  if (localUser[i][socket.username] != undefined) {
-	    socket.emit("updateRooms", {
-		  room: i
-	    });
-	  }
+    //add user's current channels
+    for (var i in localUser) {
+      if (localUser[i][socket.username] != undefined) {
+        socket.emit("updateRooms", {
+          room: i
+        });
+      }
     }
-	
-	
+
+
     if (history[socket.channel] !== undefined) {
-	  socket.emit("loadHistory", history[socket.channel]);
+      socket.emit("loadHistory", history[socket.channel]);
     } else {
-	  history[socket.channel] = [];
+      history[socket.channel] = [];
     }
   });
 
   // when the client emits 'new message', this listens and executes
   socket.on('new message', function (data) {
     // we tell the client to execute 'new message'
-	var message = {
+    var message = {
       username: socket.username,
       message: data.message,
-	  room: data.room
-	};
-	
-	if (history[data.room] === undefined) {
-	  history[data.room] = [];
-	}
-	history[data.room].push(message);
-		  
+      room: data.room
+    };
+
+    if (history[data.room] === undefined) {
+      history[data.room] = [];
+    }
+    history[data.room].push(message);
+
     socket.to(data.room).emit('new message', message);
   });
 
@@ -135,40 +134,39 @@ io.on('connection', function (socket) {
       socket.emit("loadHistory", history[data.room]);
     }
   });
-  
+
   // when the user disconnects.. perform this
   socket.on('disconnect', function () {
     if (addedUser) {
       numUsers -= 1;
-	  if (localUser[socket.channel] != undefined){
-		//user is in this chat in multiple instances
-		if (localUser[socket.channel][socket.username] > 1){
-			localUser[socket.channel][socket.username]--;
-		} 
-		else if (delete localUser[socket.channel][socket.username]) {
+      if (localUser[socket.channel] != undefined) {
+        //user is in this chat in multiple instances
+        if (localUser[socket.channel][socket.username] > 1) {
+            localUser[socket.channel][socket.username] -= 1;
+        } else if (delete localUser[socket.channel][socket.username]) {
           if (!Object.keys(localUser[socket.channel]).length) { //last user left; room now empty
             delete localUser[socket.channel];
             delete history[socket.channel];
           }
-		  
-		  io.sockets.in(socket.username).emit("updateRooms", {
-			disconnectFlag: true,
-			room: socket.channel
-		  });
-		  
+
+          io.sockets.in(socket.username).emit("updateRooms", {
+            disconnectFlag: true,
+            room: socket.channel
+          });
+
           // echo globally that this client has left
           socket.broadcast.to(socket.channel).emit('user left', {
             username: socket.username,
             numUsers: numUsers
           });
         }
-	  }
-	  
+      }
+
       io.in(socket.channel).emit("updateUsers", {
-	    usernames: localUser[socket.channel],
-	    room: socket.channel
-	  });
-	  
+        usernames: localUser[socket.channel],
+        room: socket.channel
+      });
+
       socket.leave(socket.username);
       socket.leave(socket.channel);
     }


### PR DESCRIPTION
These features from our previous version are all implemented.
Users are sent to a chatroom based on the domain host name. 
User list for that chat is displayed above the chat.
Other channels the user is in is displayed above the chat.
User can switch between channels in the channel list.

Some bugs may include: when the server is shut down and restarted, a users channels in the channel list will be displayed twice.
Sometimes when the server is shutdown and restarted the user will be in a different chat room from the URL (usually doesn't happen, hard to replicate).